### PR TITLE
Fix exceptions in XP when certain skills are disabled

### DIFF
--- a/src/main/java/com/volmit/adapt/api/xp/XP.java
+++ b/src/main/java/com/volmit/adapt/api/xp/XP.java
@@ -22,6 +22,7 @@ import com.volmit.adapt.Adapt;
 import com.volmit.adapt.AdaptConfig;
 import com.volmit.adapt.api.skill.Skill;
 import com.volmit.adapt.api.world.AdaptPlayer;
+import com.volmit.adapt.api.world.PlayerSkillLine;
 import com.volmit.adapt.util.M;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -32,7 +33,10 @@ public class XP {
     }
 
     public static void xp(AdaptPlayer p, Skill skill, double xp) {
-        p.getSkillLine(skill.getName()).giveXP(p.getNot(), xp);
+        PlayerSkillLine skillLine = p.getSkillLine(skill.getName());
+        if (skillLine != null) {
+            skillLine.giveXP(p.getNot(), xp);
+        }
     }
 
     public static void xpSilent(Player p, Skill skill, double xp) {


### PR DESCRIPTION
The issue could be reproduced by disabling the ranged skill and shooting a bow:

```
[17:14:08 ERROR]: Could not pass event ProjectileLaunchEvent to Adapt v1.3.1-1.19.2
java.lang.NullPointerException: Cannot invoke "com.volmit.adapt.api.world.PlayerSkillLine.giveXP(com.volmit.adapt.api.notification.Notifier, double)" because the return value of "com.volmit.adapt.api.world.AdaptPlayer.getSkillLine(String)" is null
        at com.volmit.adapt.api.xp.XP.xp(XP.java:35) ~[Adapt-1.3.1-1.19.2-no-stupid.jar:?]
        at com.volmit.adapt.api.xp.XP.xp(XP.java:31) ~[Adapt-1.3.1-1.19.2-no-stupid.jar:?]
        at com.volmit.adapt.api.skill.Skill.xp(Skill.java:125) ~[Adapt-1.3.1-1.19.2-no-stupid.jar:?]
        at com.volmit.adapt.api.skill.Skill.xp(Skill.java:119) ~[Adapt-1.3.1-1.19.2-no-stupid.jar:?]
        at com.volmit.adapt.api.adaptation.Adaptation.xp(Adaptation.java:48) ~[Adapt-1.3.1-1.19.2-no-stupid.jar:?]
        at com.volmit.adapt.content.adaptation.ranged.RangedPiercing.on(RangedPiercing.java:63) ~[Adapt-1.3.1-1.19.2-no-stupid.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor1744.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:76) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:git-Paper-145]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:670) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.callProjectileLaunchEvent(CraftEventFactory.java:1399) ~[paper-1.19.2.jar:git-Paper-145]
        at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.doEntityAddEventCalling(CraftEventFactory.java:649) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.server.level.ServerLevel.addEntity(ServerLevel.java:1450) ~[?:?]
        at net.minecraft.server.level.ServerLevel.addFreshEntity(ServerLevel.java:1358) ~[?:?]
        at net.minecraft.server.level.ServerLevel.addFreshEntity(ServerLevel.java:1353) ~[?:?]
        at net.minecraft.world.item.BowItem.releaseUsing(BowItem.java:85) ~[?:?]
        at net.minecraft.world.item.ItemStack.releaseUsing(ItemStack.java:757) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.world.entity.LivingEntity.releaseUsingItem(LivingEntity.java:3908) ~[?:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handlePlayerAction(ServerGamePacketListenerImpl.java:1867) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:42) ~[?:?]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.a(ServerboundPlayerActionPacket.java:15) ~[?:?]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1361) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:185) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1338) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1331) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1309) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1197) ~[paper-1.19.2.jar:git-Paper-145]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:305) ~[paper-1.19.2.jar:git-Paper-145]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```