### PR TITLE
Make learn/unlearn button delay configurable

### DIFF
--- a/src/main/java/com/volmit/adapt/AdaptConfig.java
+++ b/src/main/java/com/volmit/adapt/AdaptConfig.java
@@ -54,6 +54,7 @@ public class AdaptConfig {
     private boolean loginBonus = true;
     private boolean advancements = true;
     private boolean useSql = false;
+    private int learnUnlearnButtonDelayTicks = 14;
     private SqlSettings sql = new SqlSettings();
 
     public static AdaptConfig get() {

--- a/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
+++ b/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
@@ -321,7 +321,7 @@ public interface Adaptation<T> extends Ticked, Component {
                             player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 0.755f);
                             w.close();
                             player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "adaptmenu", "unlearned") + " " + getDisplayName(mylevel), 1, 5, 11);
-                            J.s(() -> openGui(player), 14);
+                            J.s(() -> openGui(player), AdaptConfig.get().getLearnUnlearnButtonDelayTicks());
                             return;
                         }
 
@@ -334,7 +334,7 @@ public interface Adaptation<T> extends Ticked, Component {
                                 player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_ACTIVATE, 0.2f, 1.455f);
                                 w.close();
                                 player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "adaptmenu", "learned") + " " + getDisplayName(lvl), 1, 5, 11);
-                                J.s(() -> openGui(player), 14);
+                                J.s(() -> openGui(player), AdaptConfig.get().getLearnUnlearnButtonDelayTicks());
                             } else {
                                 player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BAMBOO_HIT, 0.7f, 1.855f);
 

--- a/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
+++ b/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
@@ -320,7 +320,9 @@ public interface Adaptation<T> extends Ticked, Component {
                             player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NETHER_GOLD_ORE_PLACE, 0.7f, 1.355f);
                             player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 0.755f);
                             w.close();
-                            player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "adaptmenu", "unlearned") + " " + getDisplayName(mylevel), 1, 5, 11);
+                            if (AdaptConfig.get().getLearnUnlearnButtonDelayTicks() != 0) {
+                                player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "adaptmenu", "unlearned") + " " + getDisplayName(mylevel), 1, 5, 11);
+                            }
                             J.s(() -> openGui(player), AdaptConfig.get().getLearnUnlearnButtonDelayTicks());
                             return;
                         }
@@ -333,7 +335,9 @@ public interface Adaptation<T> extends Ticked, Component {
                                 player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_POWER_SELECT, 0.4f, 0.155f);
                                 player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_ACTIVATE, 0.2f, 1.455f);
                                 w.close();
-                                player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "adaptmenu", "learned") + " " + getDisplayName(lvl), 1, 5, 11);
+                                if (AdaptConfig.get().getLearnUnlearnButtonDelayTicks() != 0) {
+                                    player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "adaptmenu", "learned") + " " + getDisplayName(lvl), 1, 5, 11);
+                                }
                                 J.s(() -> openGui(player), AdaptConfig.get().getLearnUnlearnButtonDelayTicks());
                             } else {
                                 player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BAMBOO_HIT, 0.7f, 1.855f);


### PR DESCRIPTION
Implements the ability to change GUI close&open delay when learning or unlearning an adaption.

Preserves old behavior by default, but if someone wants to disable this delay (like #193 3.), they can set it to `0`. Also, it won't display `Learned: ...` title if the delay is 0.