### PR TITLE
Add `Unlearn all` button

### DIFF
--- a/src/main/java/com/volmit/adapt/AdaptConfig.java
+++ b/src/main/java/com/volmit/adapt/AdaptConfig.java
@@ -57,6 +57,7 @@ public class AdaptConfig {
     private int learnUnlearnButtonDelayTicks = 14;
     private boolean actionbarNotifyXp = true;
     private boolean actionbarNotifyLevel = true;
+    private boolean unlearnAllButton = false;
     private SqlSettings sql = new SqlSettings();
 
     public static AdaptConfig get() {

--- a/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
+++ b/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
@@ -315,8 +315,7 @@ public interface Adaptation<T> extends Ticked, Component {
                     .addLore(mylevel < lvl && getPlayer(player).getData().hasPowerAvailable(pc) ? C.GREEN + "" + lvl + " " + Adapt.dLocalize("snippets", "adaptmenu", "powerdrain") : mylevel >= lvl ? C.GREEN + "" + lvl + " " + Adapt.dLocalize("snippets", "adaptmenu", "powerdrain") : C.RED + Adapt.dLocalize("snippets", "adaptmenu", "notenoughpower") + "\n" + C.RED + Adapt.dLocalize("snippets", "adaptmenu", "howtolevelup"))
                     .onLeftClick((e) -> {
                         if (mylevel >= lvl) {
-                            if (!AdaptConfig.get().isHardcoreNoRefunds()) {getPlayer(player).getData().getSkillLine(getSkill().getName()).giveKnowledge(rc);}
-                            getPlayer(player).getData().getSkillLine(getSkill().getName()).setAdaptation(this, lvl - 1);
+                            unlearn(player, lvl);
                             player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NETHER_GOLD_ORE_PLACE, 0.7f, 1.355f);
                             player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 0.755f);
                             w.close();
@@ -361,6 +360,16 @@ public interface Adaptation<T> extends Ticked, Component {
             getSkill().openGui(player);
         }));
         w.open();
+    }
+
+    default void unlearn(Player player, int lvl) {
+        int mylevel = getPlayer(player).getSkillLine(getSkill().getName()).getAdaptationLevel(getName());
+        int rc = getRefundCostFor(lvl - 1, mylevel);
+
+        if (!AdaptConfig.get().isHardcoreNoRefunds()) {
+            getPlayer(player).getData().getSkillLine(getSkill().getName()).giveKnowledge(rc);
+        }
+        getPlayer(player).getData().getSkillLine(getSkill().getName()).setAdaptation(this, lvl - 1);
     }
 
     default boolean isAdaptationRecipe(Recipe recipe) {

--- a/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
+++ b/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
@@ -64,7 +64,7 @@ public class SkillsGui {
             if (AdaptConfig.get().isUnlearnAllButton()) {
                 int unlearnAllPos = w.getResolution().getWidth() - 1;
                 int unlearnAllRow = w.getViewportHeight() - 1;
-                if (ind % w.getResolution().getWidth() == 0) unlearnAllRow++;
+                if (ind % w.getResolution().getWidth() == 0 && ind / w.getResolution().getWidth() == w.getViewportHeight()) unlearnAllRow++;
                 w.setElement(unlearnAllPos, unlearnAllRow, new UIElement("unlearn-all")
                         .setMaterial(new MaterialBlock(Material.BARRIER))
                         .setName("" + C.RESET + C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnall")

--- a/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
+++ b/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
@@ -19,6 +19,7 @@
 package com.volmit.adapt.content.gui;
 
 import com.volmit.adapt.Adapt;
+import com.volmit.adapt.AdaptConfig;
 import com.volmit.adapt.api.skill.Skill;
 import com.volmit.adapt.api.world.AdaptPlayer;
 import com.volmit.adapt.api.world.PlayerAdaptation;
@@ -26,6 +27,7 @@ import com.volmit.adapt.api.world.PlayerSkillLine;
 import com.volmit.adapt.api.xp.XP;
 import com.volmit.adapt.util.*;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 
 public class SkillsGui {
@@ -58,6 +60,22 @@ public class SkillsGui {
                         .onLeftClick((e) -> sk.openGui(player)));
                 ind++;
             }
+
+            w.setElement(8, 2, new UIElement("unlearn-all")
+                    .setMaterial(new MaterialBlock(Material.BARRIER))
+                    .setName("" + C.RESET + C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnall")
+                            + (AdaptConfig.get().isHardcoreNoRefunds()
+                            ? " " + C.DARK_RED + "" + C.BOLD + Adapt.dLocalize("snippets", "adaptmenu", "norefunds")
+                            : ""))
+                    .onLeftClick((e) -> {
+                        Adapt.instance.getAdaptServer().getSkillRegistry().getSkills().forEach(skill -> skill.getAdaptations().forEach(adaptation -> adaptation.unlearn(player, 1)));
+                        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NETHER_GOLD_ORE_PLACE, 0.7f, 1.355f);
+                        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 0.755f);
+                        player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnedall"), 1, 5, 11);
+                        w.close();
+                        J.s(() -> open(player), 14);
+                    }));
+
             w.setTitle(Adapt.dLocalize("snippets", "gui", "level") + " " + (int) XP.getLevelForXp(adaptPlayer.getData().getMasterXp()) + " (" + adaptPlayer.getData().getUsedPower() + "/" + adaptPlayer.getData().getMaxPower() + " " + Adapt.dLocalize("snippets", "gui", "powerused") + ")");
             w.open();
         }

--- a/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
+++ b/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
@@ -61,25 +61,27 @@ public class SkillsGui {
                 ind++;
             }
 
-            int unlearnAllPos = w.getResolution().getWidth() - 1;
-            int unlearnAllRow = w.getViewportHeight() - 1;
-            if (ind % w.getResolution().getWidth() == 0) unlearnAllRow++;
-            w.setElement(unlearnAllPos, unlearnAllRow, new UIElement("unlearn-all")
-                    .setMaterial(new MaterialBlock(Material.BARRIER))
-                    .setName("" + C.RESET + C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnall")
-                            + (AdaptConfig.get().isHardcoreNoRefunds()
-                            ? " " + C.DARK_RED + "" + C.BOLD + Adapt.dLocalize("snippets", "adaptmenu", "norefunds")
-                            : ""))
-                    .onLeftClick((e) -> {
-                        Adapt.instance.getAdaptServer().getSkillRegistry().getSkills().forEach(skill -> skill.getAdaptations().forEach(adaptation -> adaptation.unlearn(player, 1)));
-                        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NETHER_GOLD_ORE_PLACE, 0.7f, 1.355f);
-                        player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 0.755f);
-                        w.close();
-                        if (AdaptConfig.get().getLearnUnlearnButtonDelayTicks() != 0) {
-                            player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnedall"), 1, 5, 11);
-                        }
-                        J.s(() -> open(player), AdaptConfig.get().getLearnUnlearnButtonDelayTicks());
-                    }));
+            if (AdaptConfig.get().isUnlearnAllButton()) {
+                int unlearnAllPos = w.getResolution().getWidth() - 1;
+                int unlearnAllRow = w.getViewportHeight() - 1;
+                if (ind % w.getResolution().getWidth() == 0) unlearnAllRow++;
+                w.setElement(unlearnAllPos, unlearnAllRow, new UIElement("unlearn-all")
+                        .setMaterial(new MaterialBlock(Material.BARRIER))
+                        .setName("" + C.RESET + C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnall")
+                                + (AdaptConfig.get().isHardcoreNoRefunds()
+                                ? " " + C.DARK_RED + "" + C.BOLD + Adapt.dLocalize("snippets", "adaptmenu", "norefunds")
+                                : ""))
+                        .onLeftClick((e) -> {
+                            Adapt.instance.getAdaptServer().getSkillRegistry().getSkills().forEach(skill -> skill.getAdaptations().forEach(adaptation -> adaptation.unlearn(player, 1)));
+                            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NETHER_GOLD_ORE_PLACE, 0.7f, 1.355f);
+                            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 0.755f);
+                            w.close();
+                            if (AdaptConfig.get().getLearnUnlearnButtonDelayTicks() != 0) {
+                                player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnedall"), 1, 5, 11);
+                            }
+                            J.s(() -> open(player), AdaptConfig.get().getLearnUnlearnButtonDelayTicks());
+                        }));
+            }
 
             w.setTitle(Adapt.dLocalize("snippets", "gui", "level") + " " + (int) XP.getLevelForXp(adaptPlayer.getData().getMasterXp()) + " (" + adaptPlayer.getData().getUsedPower() + "/" + adaptPlayer.getData().getMaxPower() + " " + Adapt.dLocalize("snippets", "gui", "powerused") + ")");
             w.open();

--- a/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
+++ b/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
@@ -64,7 +64,7 @@ public class SkillsGui {
             if (AdaptConfig.get().isUnlearnAllButton()) {
                 int unlearnAllPos = w.getResolution().getWidth() - 1;
                 int unlearnAllRow = w.getViewportHeight() - 1;
-                if (ind % w.getResolution().getWidth() == 0 && ind / w.getResolution().getWidth() == w.getViewportHeight()) unlearnAllRow++;
+                if (w.getElement(unlearnAllPos, unlearnAllRow) != null) unlearnAllRow++;
                 w.setElement(unlearnAllPos, unlearnAllRow, new UIElement("unlearn-all")
                         .setMaterial(new MaterialBlock(Material.BARRIER))
                         .setName("" + C.RESET + C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnall")

--- a/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
+++ b/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
@@ -74,9 +74,11 @@ public class SkillsGui {
                         Adapt.instance.getAdaptServer().getSkillRegistry().getSkills().forEach(skill -> skill.getAdaptations().forEach(adaptation -> adaptation.unlearn(player, 1)));
                         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NETHER_GOLD_ORE_PLACE, 0.7f, 1.355f);
                         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BEACON_DEACTIVATE, 0.4f, 0.755f);
-                        player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnedall"), 1, 5, 11);
                         w.close();
-                        J.s(() -> open(player), 14);
+                        if (AdaptConfig.get().getLearnUnlearnButtonDelayTicks() != 0) {
+                            player.sendTitle(" ", C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnedall"), 1, 5, 11);
+                        }
+                        J.s(() -> open(player), AdaptConfig.get().getLearnUnlearnButtonDelayTicks());
                     }));
 
             w.setTitle(Adapt.dLocalize("snippets", "gui", "level") + " " + (int) XP.getLevelForXp(adaptPlayer.getData().getMasterXp()) + " (" + adaptPlayer.getData().getUsedPower() + "/" + adaptPlayer.getData().getMaxPower() + " " + Adapt.dLocalize("snippets", "gui", "powerused") + ")");

--- a/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
+++ b/src/main/java/com/volmit/adapt/content/gui/SkillsGui.java
@@ -61,7 +61,10 @@ public class SkillsGui {
                 ind++;
             }
 
-            w.setElement(8, 2, new UIElement("unlearn-all")
+            int unlearnAllPos = w.getResolution().getWidth() - 1;
+            int unlearnAllRow = w.getViewportHeight() - 1;
+            if (ind % w.getResolution().getWidth() == 0) unlearnAllRow++;
+            w.setElement(unlearnAllPos, unlearnAllRow, new UIElement("unlearn-all")
                     .setMaterial(new MaterialBlock(Material.BARRIER))
                     .setName("" + C.RESET + C.GRAY + Adapt.dLocalize("snippets", "gui", "unlearnall")
                             + (AdaptConfig.get().isHardcoreNoRefunds()

--- a/src/main/resources/en_US.json
+++ b/src/main/resources/en_US.json
@@ -9,7 +9,9 @@
       "welcome": "Welcome!",
       "welcomeback": "Welcome back!",
       "xpbonusfortime": "XP for",
-      "unlockthisbyclicking": "Unlock this by Right-Clicking the Adapt Block!"
+      "unlockthisbyclicking": "Unlock this by Right-Clicking the Adapt Block!",
+      "unlearnall": "Unlearn all",
+      "unlearnedall": "Unlearned all"
     },
     "adaptmenu": {
       "knowledgecost": "Knowledge Cost",


### PR DESCRIPTION
This PR adds "Unlearn all" button in the skills GUI that is toggleable in config and disabled by default. The reasoning for implementing this feature is provided in #193, `4.`
It also adds `Adaptation#unlearn(Player player, int level)` method to unlearn and refund knowledge (if not in hardcore no-refund mode)