### PR TITLE
A summary of some possible problems

### DIFF
--- a/src/main/java/com/volmit/adapt/content/adaptation/stealth/StealthSnatch.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/stealth/StealthSnatch.java
@@ -94,9 +94,10 @@ public class StealthSnatch extends SimpleAdaptation<StealthSnatch.Config> {
                                 player.getWorld().playSound(player.getLocation(), Sound.BLOCK_LAVA_POP, 1f, (float) (1.0 + (Math.random() / 3)));
                             }
 
-                            player.getInventory().addItem(is);
+                            j.teleport(player.getLocation());
+//                            player.getInventory().addItem(is);
                             sendCollected(player, (Item) j);
-                            j.remove();
+//                            j.remove();
                             getSkill().xp(player, 1.27);
 
                             int id = j.getEntityId();


### PR DESCRIPTION
I took a look at your item pickup code and found that he runs it as addItem(). So let's take an example.
An other plugin creates a drop that can't be picked up, your plugin finds the drop, then remove() him and addItem() to the player's backpack. This breaks compatibility between plugins and add-ins.
So I submitted this pr to show how to deal with this problem. Of course ***this PR is problematic***, so please don't merge it. You'll see what the problem is when you look at the code.
I hope you can follow this pattern to modify the plugin to achieve maximum compatibility with other plugins.