### PR TITLE
Fixes skull toss

### DIFF
--- a/src/main/java/com/volmit/adapt/content/adaptation/nether/NetherSkullYeet.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/nether/NetherSkullYeet.java
@@ -32,6 +32,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.WitherSkull;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -81,7 +82,7 @@ public class NetherSkullYeet extends SimpleAdaptation<NetherSkullYeet.Config> {
         if (!hasAdaptation(e.getPlayer())) {
             return;
         }
-        if (e.isCancelled()) {
+        if (e.useItemInHand() == Event.Result.DENY) {
             return;
         }
 


### PR DESCRIPTION
Fixed issue with toss skull ability using deprecated event.isCanceled() function