### PR TITLE
Fix error with block hardess check

### DIFF
--- a/src/main/java/com/volmit/adapt/api/value/MaterialValue.java
+++ b/src/main/java/com/volmit/adapt/api/value/MaterialValue.java
@@ -139,9 +139,9 @@ public class MaterialValue {
 
     private static double getValue(Material m, Set<MaterialRecipe> ignore) {
         if (get().value.containsKey(m)) {
-            if (m.getHardness() == 0) {
-                return 0;
-            }
+             if (m.isBlock() && m.getHardness() == 0) {
+                 return 0;
+             }
             return get().value.get(m);
         }
         double v = AdaptConfig.get().getValue().getBaseValue();

--- a/src/main/java/com/volmit/adapt/api/value/MaterialValue.java
+++ b/src/main/java/com/volmit/adapt/api/value/MaterialValue.java
@@ -139,9 +139,9 @@ public class MaterialValue {
 
     private static double getValue(Material m, Set<MaterialRecipe> ignore) {
         if (get().value.containsKey(m)) {
-             if (m.isBlock() && m.getHardness() == 0) {
-                 return 0;
-             }
+            if (m.isBlock() && m.getHardness() == 0) {
+                return 0;
+            }
             return get().value.get(m);
         }
         double v = AdaptConfig.get().getValue().getBaseValue();


### PR DESCRIPTION
This method throws an error if checking material that is not a block, so the getValue method catch that error and returns 1 as the value for all materials.

Cause of this deconstruction skill from crafting can't work with many items like armor, instruments, etc.

Fix tested on the local environment
![image](https://user-images.githubusercontent.com/22889464/207946743-4576fa36-828f-4ca0-8405-a0b6fd64ad74.png)