### PR TITLE
Add WorldGuard flag and create a region protection API

### DIFF
--- a/src/main/java/com/volmit/adapt/Adapt.java
+++ b/src/main/java/com/volmit/adapt/Adapt.java
@@ -21,7 +21,7 @@ package com.volmit.adapt;
 import art.arcane.amulet.io.FolderWatcher;
 import com.volmit.adapt.api.data.WorldData;
 import com.volmit.adapt.api.potion.BrewingManager;
-import com.volmit.adapt.api.protection.DefaultProtectors;
+import com.volmit.adapt.api.protection.ProtectorRegistry;
 import com.volmit.adapt.api.protection.WorldGuardProtector;
 import com.volmit.adapt.api.tick.Ticker;
 import com.volmit.adapt.api.value.MaterialValue;
@@ -71,7 +71,7 @@ public class Adapt extends VolmitPlugin {
     @Override
     public void onLoad() {
         if (getServer().getPluginManager().getPlugin("WorldGuard") != null) {
-            DefaultProtectors.registerProtector(new WorldGuardProtector());
+            ProtectorRegistry.registerProtector(new WorldGuardProtector());
         }
     }
 

--- a/src/main/java/com/volmit/adapt/Adapt.java
+++ b/src/main/java/com/volmit/adapt/Adapt.java
@@ -21,6 +21,8 @@ package com.volmit.adapt;
 import art.arcane.amulet.io.FolderWatcher;
 import com.volmit.adapt.api.data.WorldData;
 import com.volmit.adapt.api.potion.BrewingManager;
+import com.volmit.adapt.api.protection.DefaultProtectors;
+import com.volmit.adapt.api.protection.WorldGuardProtector;
 import com.volmit.adapt.api.tick.Ticker;
 import com.volmit.adapt.api.value.MaterialValue;
 import com.volmit.adapt.api.world.AdaptServer;
@@ -64,6 +66,13 @@ public class Adapt extends VolmitPlugin {
     public Adapt() {
         super();
         instance = this;
+    }
+
+    @Override
+    public void onLoad() {
+        if (getServer().getPluginManager().getPlugin("WorldGuard") != null) {
+            DefaultProtectors.registerProtector(new WorldGuardProtector());
+        }
     }
 
     public static int getJavaVersion() {

--- a/src/main/java/com/volmit/adapt/AdaptConfig.java
+++ b/src/main/java/com/volmit/adapt/AdaptConfig.java
@@ -68,6 +68,11 @@ public class AdaptConfig {
     private boolean unlearnAllButton = false;
     boolean preventHunterSkillsWhenHungerApplied = true;
     private SqlSettings sql = new SqlSettings();
+    private Map<String, Map<String, Boolean>> protectionOverrides = Map.of(
+            "adaptation-name", Map.of(
+                    "WorldGuard", true
+            )
+    );
 
     @Setter
     private boolean verbose = false;

--- a/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
+++ b/src/main/java/com/volmit/adapt/api/adaptation/Adaptation.java
@@ -18,17 +18,14 @@
 
 package com.volmit.adapt.api.adaptation;
 
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.LocalPlayer;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
-import com.sk89q.worldguard.protection.flags.Flags;
-import com.sk89q.worldguard.protection.regions.RegionQuery;
+import com.google.common.collect.ImmutableList;
 import com.volmit.adapt.Adapt;
 import com.volmit.adapt.AdaptConfig;
 import com.volmit.adapt.api.Component;
 import com.volmit.adapt.api.advancement.AdaptAdvancement;
 import com.volmit.adapt.api.potion.BrewingRecipe;
+import com.volmit.adapt.api.protection.DefaultProtectors;
+import com.volmit.adapt.api.protection.Protector;
 import com.volmit.adapt.api.recipe.AdaptRecipe;
 import com.volmit.adapt.api.skill.Skill;
 import com.volmit.adapt.api.tick.Ticked;
@@ -36,6 +33,7 @@ import com.volmit.adapt.api.world.AdaptPlayer;
 import com.volmit.adapt.api.world.PlayerData;
 import com.volmit.adapt.api.world.PlayerSkillLine;
 import com.volmit.adapt.content.event.AdaptAdaptationUseEvent;
+import com.volmit.adapt.api.protection.WorldGuardProtector;
 import com.volmit.adapt.util.*;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -43,6 +41,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Recipe;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public interface Adaptation<T> extends Ticked, Component {
@@ -167,22 +166,13 @@ public interface Adaptation<T> extends Ticked, Component {
 
     void onRegisterAdvancements(List<AdaptAdvancement> advancements);
 
+    default List<Protector> getProtectors() {
+        return ImmutableList.copyOf(DefaultProtectors.getDefaultProtectors());
+    }
+
     default boolean canBuild(Player p, Location l) {
-        RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
-        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(l);
-        if (!hasBypass(p, l)) {
-            return query.testState(loc, WorldGuardPlugin.inst().wrapPlayer(p), Flags.BUILD);
-        } else {
-            return true;
-        }
+        return getProtectors().stream().allMatch(protector -> protector.canBuild(p, l, this));
     }
-
-    private boolean hasBypass(Player p, Location l) {
-        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(p);
-        com.sk89q.worldedit.world.World world = BukkitAdapter.adapt(l.getWorld());
-        return WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, world);
-    }
-
 
     default boolean hasAdaptation(Player p) {
         try {
@@ -202,10 +192,8 @@ public interface Adaptation<T> extends Ticked, Component {
                     Adapt.verbose("Player " + p.getName() + " is in creative or spectator mode. Skipping adaptation " + this.getName());
                     return false;
                 }
-                if ((Bukkit.getServer().getPluginManager().getPlugin("WorldGuard") != null && Bukkit.getServer().getPluginManager().getPlugin("WorldGuard").isEnabled())
-                        && AdaptConfig.get().isRequireWorldguardBuildPermToUseAdaptations()
-                        && !canBuild(p, p.getLocation())) {
-                    Adapt.verbose("Player " + p.getName() + " tried to use adaptation " + this.getName() + " but they don't have worldguard build permission.");
+                if (!canBuild(p, p.getLocation())) {
+                    Adapt.verbose("Player " + p.getName() + " tried to use adaptation " + this.getName() + " but they don't have build permission.");
                     return false;
                 }
                 Adapt.verbose("Player " + p.getName() + " used adaptation " + this.getName());

--- a/src/main/java/com/volmit/adapt/api/protection/DefaultProtectors.java
+++ b/src/main/java/com/volmit/adapt/api/protection/DefaultProtectors.java
@@ -1,0 +1,22 @@
+package com.volmit.adapt.api.protection;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DefaultProtectors {
+    private static final List<Protector> protectors = new ArrayList<>();
+
+    public static void registerProtector(Protector protector) {
+        protectors.add(protector);
+    }
+
+    public static void unregisterProtector(Protector protector) {
+        protectors.remove(protector);
+    }
+
+    public static List<Protector> getDefaultProtectors() {
+        return ImmutableList.copyOf(protectors);
+    }
+}

--- a/src/main/java/com/volmit/adapt/api/protection/Protector.java
+++ b/src/main/java/com/volmit/adapt/api/protection/Protector.java
@@ -4,6 +4,10 @@ import com.volmit.adapt.api.adaptation.Adaptation;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-public abstract class Protector {
-    public abstract boolean canBuild(Player player, Location location, Adaptation<?> adaptation);
+public interface Protector {
+    boolean canBuild(Player player, Location location, Adaptation<?> adaptation);
+
+    String getName();
+
+    boolean isEnabledByDefault();
 }

--- a/src/main/java/com/volmit/adapt/api/protection/Protector.java
+++ b/src/main/java/com/volmit/adapt/api/protection/Protector.java
@@ -1,0 +1,9 @@
+package com.volmit.adapt.api.protection;
+
+import com.volmit.adapt.api.adaptation.Adaptation;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public abstract class Protector {
+    public abstract boolean canBuild(Player player, Location location, Adaptation<?> adaptation);
+}

--- a/src/main/java/com/volmit/adapt/api/protection/Protector.java
+++ b/src/main/java/com/volmit/adapt/api/protection/Protector.java
@@ -1,3 +1,21 @@
+/*------------------------------------------------------------------------------
+ -   Adapt is a Skill/Integration plugin  for Minecraft Bukkit Servers
+ -   Copyright (c) 2022 Arcane Arts (Volmit Software)
+ -
+ -   This program is free software: you can redistribute it and/or modify
+ -   it under the terms of the GNU General Public License as published by
+ -   the Free Software Foundation, either version 3 of the License, or
+ -   (at your option) any later version.
+ -
+ -   This program is distributed in the hope that it will be useful,
+ -   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ -   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ -   GNU General Public License for more details.
+ -
+ -   You should have received a copy of the GNU General Public License
+ -   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -----------------------------------------------------------------------------*/
+
 package com.volmit.adapt.api.protection;
 
 import com.volmit.adapt.api.adaptation.Adaptation;

--- a/src/main/java/com/volmit/adapt/api/protection/ProtectorRegistry.java
+++ b/src/main/java/com/volmit/adapt/api/protection/ProtectorRegistry.java
@@ -4,8 +4,9 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public class DefaultProtectors {
+public class ProtectorRegistry {
     private static final List<Protector> protectors = new ArrayList<>();
 
     public static void registerProtector(Protector protector) {
@@ -17,6 +18,10 @@ public class DefaultProtectors {
     }
 
     public static List<Protector> getDefaultProtectors() {
+        return protectors.stream().filter(Protector::isEnabledByDefault).collect(ImmutableList.toImmutableList());
+    }
+
+    public static List<Protector> getAllProtectors() {
         return ImmutableList.copyOf(protectors);
     }
 }

--- a/src/main/java/com/volmit/adapt/api/protection/ProtectorRegistry.java
+++ b/src/main/java/com/volmit/adapt/api/protection/ProtectorRegistry.java
@@ -1,3 +1,21 @@
+/*------------------------------------------------------------------------------
+ -   Adapt is a Skill/Integration plugin  for Minecraft Bukkit Servers
+ -   Copyright (c) 2022 Arcane Arts (Volmit Software)
+ -
+ -   This program is free software: you can redistribute it and/or modify
+ -   it under the terms of the GNU General Public License as published by
+ -   the Free Software Foundation, either version 3 of the License, or
+ -   (at your option) any later version.
+ -
+ -   This program is distributed in the hope that it will be useful,
+ -   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ -   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ -   GNU General Public License for more details.
+ -
+ -   You should have received a copy of the GNU General Public License
+ -   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -----------------------------------------------------------------------------*/
+
 package com.volmit.adapt.api.protection;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/com/volmit/adapt/api/protection/WorldGuardProtector.java
+++ b/src/main/java/com/volmit/adapt/api/protection/WorldGuardProtector.java
@@ -1,3 +1,21 @@
+/*------------------------------------------------------------------------------
+ -   Adapt is a Skill/Integration plugin  for Minecraft Bukkit Servers
+ -   Copyright (c) 2022 Arcane Arts (Volmit Software)
+ -
+ -   This program is free software: you can redistribute it and/or modify
+ -   it under the terms of the GNU General Public License as published by
+ -   the Free Software Foundation, either version 3 of the License, or
+ -   (at your option) any later version.
+ -
+ -   This program is distributed in the hope that it will be useful,
+ -   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ -   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ -   GNU General Public License for more details.
+ -
+ -   You should have received a copy of the GNU General Public License
+ -   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -----------------------------------------------------------------------------*/
+
 package com.volmit.adapt.api.protection;
 
 import com.sk89q.worldedit.bukkit.BukkitAdapter;

--- a/src/main/java/com/volmit/adapt/api/protection/WorldGuardProtector.java
+++ b/src/main/java/com/volmit/adapt/api/protection/WorldGuardProtector.java
@@ -1,0 +1,38 @@
+package com.volmit.adapt.api.protection;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import com.volmit.adapt.AdaptConfig;
+import com.volmit.adapt.api.adaptation.Adaptation;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class WorldGuardProtector extends Protector {
+    private final StateFlag flag;
+
+    public WorldGuardProtector() {
+        this.flag = new StateFlag("use-adaptations", !AdaptConfig.get().isRequireWorldguardBuildPermToUseAdaptations());
+        WorldGuard.getInstance().getFlagRegistry().register(flag);
+    }
+
+    @Override
+    public boolean canBuild(Player p, Location l, Adaptation<?> adaptation) {
+        RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
+        com.sk89q.worldedit.util.Location loc = BukkitAdapter.adapt(l);
+        if (!hasBypass(p, l)) {
+            return query.testBuild(loc, WorldGuardPlugin.inst().wrapPlayer(p), flag);
+        } else {
+            return true;
+        }
+    }
+
+    private boolean hasBypass(Player p, Location l) {
+        LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(p);
+        com.sk89q.worldedit.world.World world = BukkitAdapter.adapt(l.getWorld());
+        return WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, world);
+    }
+}

--- a/src/main/java/com/volmit/adapt/api/protection/WorldGuardProtector.java
+++ b/src/main/java/com/volmit/adapt/api/protection/WorldGuardProtector.java
@@ -11,11 +11,11 @@ import com.volmit.adapt.api.adaptation.Adaptation;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-public class WorldGuardProtector extends Protector {
+public class WorldGuardProtector implements Protector {
     private final StateFlag flag;
 
     public WorldGuardProtector() {
-        this.flag = new StateFlag("use-adaptations", !AdaptConfig.get().isRequireWorldguardBuildPermToUseAdaptations());
+        this.flag = new StateFlag("use-adaptations", false);
         WorldGuard.getInstance().getFlagRegistry().register(flag);
     }
 
@@ -28,6 +28,16 @@ public class WorldGuardProtector extends Protector {
         } else {
             return true;
         }
+    }
+
+    @Override
+    public String getName() {
+        return "WorldGuard";
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return AdaptConfig.get().isRequireWorldguardBuildPermToUseAdaptations();
     }
 
     private boolean hasBypass(Player p, Location l) {

--- a/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeVeinminer.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeVeinminer.java
@@ -19,7 +19,6 @@
 package com.volmit.adapt.content.adaptation.pickaxe;
 
 import com.volmit.adapt.Adapt;
-import com.volmit.adapt.AdaptConfig;
 import com.volmit.adapt.api.adaptation.SimpleAdaptation;
 import com.volmit.adapt.util.C;
 import com.volmit.adapt.util.Element;
@@ -90,10 +89,8 @@ public class PickaxeVeinminer extends SimpleAdaptation<PickaxeVeinminer.Config> 
                         Block b = block.getRelative(x, y, z);
                         if (b.getType() == block.getType()) {
                             //might fix the veinminer issue. no Clue!
-                            if ((Bukkit.getServer().getPluginManager().getPlugin("WorldGuard") != null && Bukkit.getServer().getPluginManager().getPlugin("WorldGuard").isEnabled())
-                                    && AdaptConfig.get().isRequireWorldguardBuildPermToUseAdaptations()
-                                    && !canBuild(p, p.getLocation())) {
-                                Adapt.verbose("Player " + p.getName() + " tried to use Veinminer but doesn't have WorldGuard build permission.");
+                            if (!canBuild(p, p.getLocation())) {
+                                Adapt.verbose("Player " + p.getName() + " tried to use Veinminer but doesn't have build permission.");
                                 return;
                             }
                             blockMap.put(b.getLocation(), b);


### PR DESCRIPTION
This PR moves region protection code to a separate package (`com.volmit.adapt.api.protection`), adds protection API (`DefaultProtectors.registerProtector(Protector)`) so other plugins can add their own implementations, and adds `use-adaptations` flag. If the flag is not defined in the WG region, the default value is `allow` if `requireWorldguardBuildPermToUseAdaptations: false` or if the player has `build` permission in the region, I think that's how it worked before this PR.