### PR TITLE
Add global boost command

### DIFF
--- a/src/main/java/com/volmit/adapt/api/skill/SkillRegistry.java
+++ b/src/main/java/com/volmit/adapt/api/skill/SkillRegistry.java
@@ -18,6 +18,7 @@
 
 package com.volmit.adapt.api.skill;
 
+import com.volmit.adapt.Adapt;
 import com.volmit.adapt.AdaptConfig;
 import com.volmit.adapt.api.potion.BrewingManager;
 import com.volmit.adapt.api.recipe.AdaptRecipe;
@@ -128,6 +129,11 @@ public class SkillRegistry extends TickedObject {
                 Bukkit.getServer().getConsoleSender().sendMessage("Global" + C.GRAY + ": " + C.GREEN + xv);
 
                 for (XPMultiplier i : a.getData().getMultipliers()) {
+                    String vv = i.getMultiplier() > 0 ? "+" + Form.pc(i.getMultiplier()) : Form.pc(i.getMultiplier());
+                    Bukkit.getServer().getConsoleSender().sendMessage(C.GREEN + "* " + vv + C.GRAY + " for " + Form.duration(i.getGoodFor() - M.ms(), 0));
+                }
+
+                for (XPMultiplier i : Adapt.instance.getAdaptServer().getData().getMultipliers()) {
                     String vv = i.getMultiplier() > 0 ? "+" + Form.pc(i.getMultiplier()) : Form.pc(i.getMultiplier());
                     Bukkit.getServer().getConsoleSender().sendMessage(C.GREEN + "* " + vv + C.GRAY + " for " + Form.duration(i.getGoodFor() - M.ms(), 0));
                 }

--- a/src/main/java/com/volmit/adapt/api/world/AdaptServerData.java
+++ b/src/main/java/com/volmit/adapt/api/world/AdaptServerData.java
@@ -1,0 +1,14 @@
+package com.volmit.adapt.api.world;
+
+import com.volmit.adapt.api.xp.XPMultiplier;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class AdaptServerData {
+    private List<XPMultiplier> multipliers = new ArrayList<>();
+}

--- a/src/main/java/com/volmit/adapt/api/world/AdaptServerData.java
+++ b/src/main/java/com/volmit/adapt/api/world/AdaptServerData.java
@@ -1,3 +1,21 @@
+/*------------------------------------------------------------------------------
+ -   Adapt is a Skill/Integration plugin  for Minecraft Bukkit Servers
+ -   Copyright (c) 2022 Arcane Arts (Volmit Software)
+ -
+ -   This program is free software: you can redistribute it and/or modify
+ -   it under the terms of the GNU General Public License as published by
+ -   the Free Software Foundation, either version 3 of the License, or
+ -   (at your option) any later version.
+ -
+ -   This program is distributed in the hope that it will be useful,
+ -   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ -   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ -   GNU General Public License for more details.
+ -
+ -   You should have received a copy of the GNU General Public License
+ -   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -----------------------------------------------------------------------------*/
+
 package com.volmit.adapt.api.world;
 
 import com.volmit.adapt.api.xp.XPMultiplier;

--- a/src/main/java/com/volmit/adapt/api/world/PlayerData.java
+++ b/src/main/java/com/volmit/adapt/api/world/PlayerData.java
@@ -102,6 +102,15 @@ public class PlayerData {
             m += i.getMultiplier();
         }
 
+        for (XPMultiplier i : Adapt.instance.getAdaptServer().getData().getMultipliers().copy()) {
+            if (i.isExpired()) {
+                Adapt.instance.getAdaptServer().getData().getMultipliers().remove(i);
+                continue;
+            }
+
+            m += i.getMultiplier();
+        }
+
         if (m <= 0) {
             m = 0.01;
         }

--- a/src/main/java/com/volmit/adapt/commands/boost/CommandBoostGlobal.java
+++ b/src/main/java/com/volmit/adapt/commands/boost/CommandBoostGlobal.java
@@ -18,38 +18,37 @@
 
 package com.volmit.adapt.commands.boost;
 
-import com.volmit.adapt.util.Command;
+import com.volmit.adapt.Adapt;
+import com.volmit.adapt.api.world.AdaptServer;
 import com.volmit.adapt.util.MortarCommand;
 import com.volmit.adapt.util.MortarSender;
 
 import java.util.List;
 
-public class CommandBoost extends MortarCommand {
-    private static final List<String> permission = List.of("adapt.boost");
-    @Command
-    private final CommandBoostPlayer player = new CommandBoostPlayer();
-    @Command
-    private final CommandBoostGlobal global = new CommandBoostGlobal();
-
-    public CommandBoost() {
-        super("boost", "b");
-    }
-
-
-    @Override
-    public List<String> getRequiredPermissions() {
-        return permission;
+public class CommandBoostGlobal extends MortarCommand {
+    public CommandBoostGlobal() {
+        super("global", "g");
     }
 
     @Override
     public boolean handle(MortarSender sender, String[] args) {
-        printHelp(sender);
-        return true;
+        try {
+            AdaptServer as = Adapt.instance.getAdaptServer();
+
+            as.boostXP(Double.parseDouble(args[0]), Integer.parseInt(args[1]));
+            Adapt.info("BOOSTED " + args[0] + " XP TO " + args[1] + " ALL SKILL GAINS");
+            sender.sendMessage("BOOSTED " + args[0] + " XP TO " + args[1] + " ALL SKILL GAINS");
+
+            return true;
+        } catch (Exception ignored) {
+            Adapt.verbose("BOOST FAILED");
+            printHelp(sender);
+            return true;
+        }
     }
 
     @Override
     public void addTabOptions(MortarSender sender, String[] args, List<String> list) {
-
     }
 
     @Override


### PR DESCRIPTION
Added `/adapt boost global <multiplier> <ms>`. Works like `/adapt boost player`, but saves the information in `plugins/Adapt/data/server-data.json`. Maybe there's a better location for saving global data such as global boosts, I couldn't find a file that saves server data, so I created a new one.