### PR TITLE
Implement Factions protector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ repositories {
     maven { url = 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
     mavenCentral()
     maven { url 'https://jitpack.io' }
+    maven { url 'https://ci.ender.zone/plugin/repository/everything/' }
 }
 
 /**
@@ -146,6 +147,7 @@ dependencies {
     implementation 'me.clip:placeholderapi:2.11.2'
     implementation 'com.github.LoneDev6:api-itemsadder:3.2.5'
     implementation 'io.th0rgal:oraxen:1.94.0'
+    implementation 'com.massivecraft:Factions:1.6.9.5-U0.6.21'
 
 
     // Shaded

--- a/src/main/java/com/volmit/adapt/Adapt.java
+++ b/src/main/java/com/volmit/adapt/Adapt.java
@@ -21,8 +21,9 @@ package com.volmit.adapt;
 import art.arcane.amulet.io.FolderWatcher;
 import com.volmit.adapt.api.data.WorldData;
 import com.volmit.adapt.api.potion.BrewingManager;
+import com.volmit.adapt.content.protector.FactionsClaimProtector;
 import com.volmit.adapt.api.protection.ProtectorRegistry;
-import com.volmit.adapt.api.protection.WorldGuardProtector;
+import com.volmit.adapt.content.protector.WorldGuardProtector;
 import com.volmit.adapt.api.tick.Ticker;
 import com.volmit.adapt.api.value.MaterialValue;
 import com.volmit.adapt.api.world.AdaptServer;
@@ -70,9 +71,7 @@ public class Adapt extends VolmitPlugin {
 
     @Override
     public void onLoad() {
-        if (getServer().getPluginManager().getPlugin("WorldGuard") != null) {
-            ProtectorRegistry.registerProtector(new WorldGuardProtector());
-        }
+        loadDefaultProtectors();
     }
 
     public static int getJavaVersion() {
@@ -236,5 +235,12 @@ public class Adapt extends VolmitPlugin {
         }
     }
 
-
+    private void loadDefaultProtectors() {
+        if (getServer().getPluginManager().getPlugin("WorldGuard") != null) {
+            ProtectorRegistry.registerProtector(new WorldGuardProtector());
+        }
+        if (getServer().getPluginManager().getPlugin("Factions") != null) {
+            ProtectorRegistry.registerProtector(new FactionsClaimProtector());
+        }
+    }
 }

--- a/src/main/java/com/volmit/adapt/AdaptConfig.java
+++ b/src/main/java/com/volmit/adapt/AdaptConfig.java
@@ -53,6 +53,7 @@ public class AdaptConfig {
     private double playerXpPerSkillLevelUpLevelMultiplier = 44;
     private double powerPerLevel = 0.73;
     private boolean requireWorldguardBuildPermToUseAdaptations = true;
+    private boolean requireFactionClaimOwnershipToUseAdaptations = false;
     private boolean hardcoreResetOnPlayerDeath = false;
     private boolean hardcoreNoRefunds = false;
     private boolean loginBonus = true;

--- a/src/main/java/com/volmit/adapt/content/protector/FactionsClaimProtector.java
+++ b/src/main/java/com/volmit/adapt/content/protector/FactionsClaimProtector.java
@@ -1,0 +1,48 @@
+/*------------------------------------------------------------------------------
+ -   Adapt is a Skill/Integration plugin  for Minecraft Bukkit Servers
+ -   Copyright (c) 2022 Arcane Arts (Volmit Software)
+ -
+ -   This program is free software: you can redistribute it and/or modify
+ -   it under the terms of the GNU General Public License as published by
+ -   the Free Software Foundation, either version 3 of the License, or
+ -   (at your option) any later version.
+ -
+ -   This program is distributed in the hope that it will be useful,
+ -   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ -   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ -   GNU General Public License for more details.
+ -
+ -   You should have received a copy of the GNU General Public License
+ -   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -----------------------------------------------------------------------------*/
+
+package com.volmit.adapt.content.protector;
+
+import com.massivecraft.factions.*;
+import com.volmit.adapt.AdaptConfig;
+import com.volmit.adapt.api.adaptation.Adaptation;
+import com.volmit.adapt.api.protection.Protector;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class FactionsClaimProtector implements Protector {
+    @Override
+    public boolean canBuild(Player p, Location l, Adaptation<?> adaptation) {
+        Faction f = Board.getInstance().getFactionAt(new FLocation(l));
+        FPlayer fp = FPlayers.getInstance().getByPlayer(p);
+        return f == null
+                || f.isWilderness()
+                || fp.getFaction() == f
+                || fp.isAdminBypassing();
+    }
+
+    @Override
+    public String getName() {
+        return "Factions";
+    }
+
+    @Override
+    public boolean isEnabledByDefault() {
+        return AdaptConfig.get().isRequireFactionClaimOwnershipToUseAdaptations();
+    }
+}

--- a/src/main/java/com/volmit/adapt/content/protector/WorldGuardProtector.java
+++ b/src/main/java/com/volmit/adapt/content/protector/WorldGuardProtector.java
@@ -16,7 +16,7 @@
  -   along with this program.  If not, see <https://www.gnu.org/licenses/>.
  -----------------------------------------------------------------------------*/
 
-package com.volmit.adapt.api.protection;
+package com.volmit.adapt.content.protector;
 
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.LocalPlayer;
@@ -26,6 +26,7 @@ import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 import com.volmit.adapt.AdaptConfig;
 import com.volmit.adapt.api.adaptation.Adaptation;
+import com.volmit.adapt.api.protection.Protector;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: com.volmit.adapt.Adapt
 version: ${version}
 authors: [ NextdoorPsycho, Cyberpwn,  Vatuu ]
 api-version: ${apiversion}
-softdepend: [ PlaceholderAPI, WorldGuard ]
+softdepend: [ PlaceholderAPI, WorldGuard, Factions ]
 libraries:
   - com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:1.4.2
   - org.apache.commons:commons-lang3:3.12.0


### PR DESCRIPTION
Added `requireFactionClaimOwnershipToUseAdaptations` setting (default is `false`), moved default protectors to `com.volmit.adapt.content.protector` package (from `api` to `content`), and moved the default protector initialization code to the `loadDefaultProtectors()` method. Works with FactionsUUID, SaberFactions, and probably other forks as well.