### PR TITLE
Fix GUI Lore

### DIFF
--- a/src/main/java/com/volmit/adapt/content/adaptation/agility/AgilityWindUp.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/agility/AgilityWindUp.java
@@ -54,8 +54,8 @@ public class AgilityWindUp extends SimpleAdaptation<AgilityWindUp.Config> {
 
     @Override
     public void addStats(int level, Element v) {
-        v.addLore(C.GREEN + "+ " + Form.pc(getWindupSpeed(getLevelPercent(level)), 0) + C.GRAY + Localizer.dLocalize("agility", "windup", "lore1"));
-        v.addLore(C.YELLOW + "* " + Form.duration(getWindupTicks(getLevelPercent(level)) * 50D, 1) + C.GRAY + Localizer.dLocalize("agility", "windup", "lore2"));
+        v.addLore(C.GREEN + "+ " + Form.pc(getWindupSpeed(getLevelPercent(level)), 0) + C.GRAY + " " + Localizer.dLocalize("agility", "windup", "lore1"));
+        v.addLore(C.YELLOW + "* " + Form.duration(getWindupTicks(getLevelPercent(level)) * 50D, 1) + C.GRAY + " " + Localizer.dLocalize("agility", "windup", "lore2"));
     }
 
     @EventHandler


### PR DESCRIPTION
Adds a space between the skill and the lore. Check screenshots. 
![image](https://i.johnfries.net/images/04_17_24_16_22_52.png)
![image](https://i.johnfries.net/images/04_17_24_16_21_22.png)
