### PR TITLE
Fix API and add new teleportation event

### DIFF
--- a/src/main/java/com/volmit/adapt/content/adaptation/rift/RiftBlink.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/rift/RiftBlink.java
@@ -20,6 +20,8 @@ package com.volmit.adapt.content.adaptation.rift;
 
 import com.volmit.adapt.Adapt;
 import com.volmit.adapt.api.adaptation.SimpleAdaptation;
+import com.volmit.adapt.api.world.AdaptPlayer;
+import com.volmit.adapt.content.event.AdaptAdaptationTeleportEvent;
 import com.volmit.adapt.util.*;
 import lombok.NoArgsConstructor;
 import org.bukkit.*;
@@ -115,7 +117,15 @@ public class RiftBlink extends SimpleAdaptation<RiftBlink.Config> {
                 }
                 Vector v = p.getVelocity().clone();
                 loadChunkAsync(loc, chunk -> {
-                    J.s(() -> p.teleport(loc.add(0, 1, 0), PlayerTeleportEvent.TeleportCause.PLUGIN));
+                    Location toLoc = loc.add(0, 1, 0);
+
+                    AdaptAdaptationTeleportEvent event = new AdaptAdaptationTeleportEvent(!Bukkit.isPrimaryThread(), getPlayer(p), this, locOG, loc);
+                    Bukkit.getPluginManager().callEvent(event);
+                    if (event.isCancelled()) {
+                        return;
+                    }
+
+                    J.s(() -> p.teleport(toLoc, PlayerTeleportEvent.TeleportCause.PLUGIN));
                     J.s(() -> p.setVelocity(v.multiply(3)), 2);
                 });
                 lastJump.put(p, M.ms());

--- a/src/main/java/com/volmit/adapt/content/adaptation/rift/RiftGate.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/rift/RiftGate.java
@@ -21,6 +21,7 @@ package com.volmit.adapt.content.adaptation.rift;
 import com.volmit.adapt.Adapt;
 import com.volmit.adapt.api.adaptation.SimpleAdaptation;
 import com.volmit.adapt.api.recipe.AdaptRecipe;
+import com.volmit.adapt.content.event.AdaptAdaptationTeleportEvent;
 import com.volmit.adapt.content.item.BoundEyeOfEnder;
 import com.volmit.adapt.util.C;
 import com.volmit.adapt.util.Element;
@@ -202,6 +203,12 @@ public class RiftGate extends SimpleAdaptation<RiftGate.Config> {
         vfxLevelUp(p);
         p.playSound(p.getLocation(), Sound.BLOCK_ENDER_CHEST_OPEN, 5.35f, 0.1f);
         J.s(() -> {
+            AdaptAdaptationTeleportEvent event = new AdaptAdaptationTeleportEvent(!Bukkit.isPrimaryThread(), getPlayer(p), this, p.getLocation(), l);
+            Bukkit.getPluginManager().callEvent(event);
+            if (event.isCancelled()) {
+                return;
+            }
+
             p.teleport(l, PlayerTeleportEvent.TeleportCause.PLUGIN);
             vfxLevelUp(p);
             p.playSound(p.getLocation(), Sound.BLOCK_ENDER_CHEST_OPEN, 5.35f, 0.1f);

--- a/src/main/java/com/volmit/adapt/content/event/AdaptAdaptationTeleportEvent.java
+++ b/src/main/java/com/volmit/adapt/content/event/AdaptAdaptationTeleportEvent.java
@@ -1,0 +1,35 @@
+/*------------------------------------------------------------------------------
+ -   Adapt is a Skill/Integration plugin  for Minecraft Bukkit Servers
+ -   Copyright (c) 2022 Arcane Arts (Volmit Software)
+ -
+ -   This program is free software: you can redistribute it and/or modify
+ -   it under the terms of the GNU General Public License as published by
+ -   the Free Software Foundation, either version 3 of the License, or
+ -   (at your option) any later version.
+ -
+ -   This program is distributed in the hope that it will be useful,
+ -   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ -   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ -   GNU General Public License for more details.
+ -
+ -   You should have received a copy of the GNU General Public License
+ -   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -----------------------------------------------------------------------------*/
+
+package com.volmit.adapt.content.event;
+
+import com.volmit.adapt.api.adaptation.Adaptation;
+import com.volmit.adapt.api.world.AdaptPlayer;
+import lombok.Getter;
+import org.bukkit.Location;
+
+public class AdaptAdaptationTeleportEvent extends AdaptAdaptationEvent {
+    @Getter
+    Location fromLocation, toLocation;
+
+    public AdaptAdaptationTeleportEvent(boolean async, AdaptPlayer player, Adaptation<?> adaptation, Location fromLocation, Location toLocation) {
+        super(async, player, adaptation);
+        this.fromLocation = fromLocation;
+        this.toLocation = toLocation;
+    }
+}

--- a/src/main/java/com/volmit/adapt/content/event/AdaptEvent.java
+++ b/src/main/java/com/volmit/adapt/content/event/AdaptEvent.java
@@ -26,7 +26,7 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 public class AdaptEvent extends Event implements Cancellable {
-    private static final HandlerList handlers = new HandlerList();
+    private static final HandlerList HANDLERS = new HandlerList();
     private boolean canceled;
 
 
@@ -49,9 +49,12 @@ public class AdaptEvent extends Event implements Cancellable {
         canceled = b;
     }
 
-    @NotNull
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
     @Override
     public HandlerList getHandlers() {
-        return handlers;
+        return HANDLERS;
     }
 }


### PR DESCRIPTION
This PR fixes the AdaptAdaptationUse event, as AdaptEvent had incorrect methods for getting handlers, resulting in the event not firing at all.

Additionally, this PR adds a new cancellable event for adaptations that involve teleportation, namely, Rift Blink and Rift Gate.