### PR TITLE
Various AutoSmelt fixes and improvements

### DIFF
--- a/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeAutosmelt.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeAutosmelt.java
@@ -34,6 +34,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.HashMap;
 import java.util.Random;
 
 public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> {
@@ -64,9 +65,8 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
                 }
 
                 b.setType(Material.AIR);
-                if (!p.getInventory().addItem(new ItemStack(Material.IRON_INGOT, fortune)).isEmpty()) {
-                    b.getLocation().getWorld().dropItemNaturally(b.getLocation(), new ItemStack(Material.IRON_INGOT, fortune));
-                }
+                HashMap<Integer, ItemStack> excessItems = p.getInventory().addItem(new ItemStack(Material.IRON_INGOT, fortune));
+                excessItems.values().forEach(itemStack -> b.getLocation().getWorld().dropItemNaturally(b.getLocation(), itemStack));
                 b.getWorld().playSound(b.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
                 b.getWorld().spawnParticle(Particle.LAVA, b.getLocation(), 3, 0.5, 0.5, 0.5);
             }
@@ -76,9 +76,8 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
                 }
 
                 b.setType(Material.AIR);
-                if (!p.getInventory().addItem(new ItemStack(Material.GOLD_INGOT, fortune)).isEmpty()) {
-                    b.getLocation().getWorld().dropItemNaturally(b.getLocation(), new ItemStack(Material.GOLD_INGOT, fortune));
-                }
+                HashMap<Integer, ItemStack> excessItems = p.getInventory().addItem(new ItemStack(Material.GOLD_INGOT, fortune));
+                excessItems.values().forEach(itemStack -> b.getLocation().getWorld().dropItemNaturally(b.getLocation(), itemStack));
                 b.getWorld().playSound(b.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
                 b.getWorld().spawnParticle(Particle.LAVA, b.getLocation(), 3, 0.5, 0.5, 0.5);
             }
@@ -87,9 +86,8 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
                     return;
                 }
                 b.setType(Material.AIR);
-                if (!p.getInventory().addItem(new ItemStack(Material.COPPER_INGOT, fortune)).isEmpty()) {
-                    b.getLocation().getWorld().dropItemNaturally(b.getLocation(), new ItemStack(Material.COPPER_INGOT, fortune));
-                }
+                HashMap<Integer, ItemStack> excessItems = p.getInventory().addItem(new ItemStack(Material.COPPER_INGOT, fortune));
+                excessItems.values().forEach(itemStack -> b.getLocation().getWorld().dropItemNaturally(b.getLocation(), itemStack));
                 b.getWorld().playSound(b.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
                 b.getWorld().spawnParticle(Particle.LAVA, b.getLocation(), 3, 0.5, 0.5, 0.5);
             }

--- a/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeAutosmelt.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeAutosmelt.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.Random;
 
 public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> {
+    private static final Random RANDOM = new Random();
+
     public PickaxeAutosmelt() {
         super("pickaxe-autosmelt");
         registerConfiguration(PickaxeAutosmelt.Config.class);
@@ -52,12 +54,8 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
     }
 
     static void autosmeltBlockDTI(Block b, Player p) {
-        int fortune = 1;
-        Random random = new Random();
-        if (p.getInventory().getItemInMainHand().getEnchantments().get(Enchantment.LOOT_BONUS_BLOCKS) != null) {
-            fortune = p.getInventory().getItemInMainHand().getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS) + (random.nextInt(3));
-
-        }
+        int fortune = getFortuneOreMultiplier(p.getInventory().getItemInMainHand()
+                .getEnchantments().get(Enchantment.LOOT_BONUS_BLOCKS));
         switch (b.getType()) {
             case IRON_ORE, DEEPSLATE_IRON_ORE -> {
                 if (b.getLocation().getWorld() == null) {
@@ -96,12 +94,8 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
     }
 
     static void autosmeltBlock(Block b, Player p) {
-        int fortune = 1;
-        Random random = new Random();
-        if (p.getInventory().getItemInMainHand().getEnchantments().get(Enchantment.LOOT_BONUS_BLOCKS) != null) {
-            fortune = p.getInventory().getItemInMainHand().getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS) + (random.nextInt(3));
-
-        }
+        int fortune = getFortuneOreMultiplier(p.getInventory().getItemInMainHand()
+                .getEnchantments().get(Enchantment.LOOT_BONUS_BLOCKS));
         switch (b.getType()) {
             case IRON_ORE, DEEPSLATE_IRON_ORE -> {
 
@@ -135,6 +129,19 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
             }
 
         }
+    }
+
+    // https://minecraft.fandom.com/wiki/Fortune?oldid=2359015#Ore
+    private static int getFortuneOreMultiplier(Integer fortuneLevel) {
+        if (fortuneLevel == null || fortuneLevel < 1) return 1;
+
+        double averageBonusMultiplier = (1.0/(fortuneLevel+2) + (fortuneLevel+1)/2.0) - 1;
+        int sumOfBonusMultipliers = (fortuneLevel*(fortuneLevel+1))/2;
+        double chancePerMultiplier = averageBonusMultiplier/sumOfBonusMultipliers;
+
+        int bonusMultiplier = ((int) (RANDOM.nextDouble()/chancePerMultiplier)) + 1;
+
+        return bonusMultiplier <= fortuneLevel ? bonusMultiplier+1 : 1;
     }
 
     @Override

--- a/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeAutosmelt.java
+++ b/src/main/java/com/volmit/adapt/content/adaptation/pickaxe/PickaxeAutosmelt.java
@@ -70,7 +70,7 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
                 b.getWorld().playSound(b.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
                 b.getWorld().spawnParticle(Particle.LAVA, b.getLocation(), 3, 0.5, 0.5, 0.5);
             }
-            case GOLD_ORE, DEEPSLATE_GOLD_ORE, NETHER_GOLD_ORE -> {
+            case GOLD_ORE, DEEPSLATE_GOLD_ORE -> {
                 if (b.getLocation().getWorld() == null) {
                     return;
                 }
@@ -116,7 +116,7 @@ public class PickaxeAutosmelt extends SimpleAdaptation<PickaxeAutosmelt.Config> 
                 b.getWorld().playSound(b.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
                 b.getWorld().spawnParticle(Particle.LAVA, b.getLocation(), 3, 0.5, 0.5, 0.5);
             }
-            case GOLD_ORE, DEEPSLATE_GOLD_ORE, NETHER_GOLD_ORE -> {
+            case GOLD_ORE, DEEPSLATE_GOLD_ORE -> {
                 if (b.getLocation().getWorld() == null) {
                     return;
                 }


### PR DESCRIPTION
There's one thing I didn't touch and not sure if it can lead to an infinite place&break farm is what would happen with an unusual Silk Touch + Fortune combo, normal behavior is Silk Touch overrides when it happens.

Also if you test new fortune calculation along with previous cooldown cleanup on a test server would be good, just to make sure there isn't a mistake in code.