### PR TITLE
Add advancements for Brewing, Nether, Ranged, Rift, and Seaborne skills

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ version '1.15.0-1.19.2-1.21'
 def apiVersion = '1.19'
 def name = getRootProject().getName() // Defined in settings.gradle
 def main = 'com.volmit.adapt.Adapt'
-def manifoldVersion = '2024.1.10'
+def manifoldVersion = '2024.1.20'
 
 // ADD YOURSELF AS A NEW LINE IF YOU WANT YOUR OWN BUILD TASK GENERATED
 // ======================== WINDOWS =============================
@@ -39,7 +39,7 @@ registerCustomOutputTask('CrazyDev22', 'C://Users/Julian/Desktop/server/plugins'
 registerCustomOutputTask('Pixel', 'D://Iris Dimension Engine//1.20.4 - Development//plugins')
 // ========================== UNIX ==============================
 registerCustomOutputTaskUnix('CyberpwnLT', '/Users/danielmills/development/server/plugins')
-registerCustomOutputTaskUnix('PsychoLT', '/Users/brianfopiano/Developer/RemoteGit/Server/plugins')
+registerCustomOutputTaskUnix('PsychoLT', '/Users/brianfopiano/Developer/RemoteGit/Server/plugins', false)
 registerCustomOutputTaskUnix('the456gamer', '/home/the456gamer/projects/minecraft/adapt-testserver/plugins/update/', false)
 // ==============================================================
 

--- a/src/main/java/com/volmit/adapt/content/skill/SkillNether.java
+++ b/src/main/java/com/volmit/adapt/content/skill/SkillNether.java
@@ -18,7 +18,11 @@
 
 package com.volmit.adapt.content.skill;
 
+import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
+import com.volmit.adapt.api.advancement.AdaptAdvancement;
+import com.volmit.adapt.api.advancement.AdvancementVisibility;
 import com.volmit.adapt.api.skill.SimpleSkill;
+import com.volmit.adapt.api.world.AdaptStatTracker;
 import com.volmit.adapt.content.adaptation.nether.NetherFireResist;
 import com.volmit.adapt.content.adaptation.nether.NetherSkullYeet;
 import com.volmit.adapt.content.adaptation.nether.NetherWitherResist;
@@ -51,6 +55,42 @@ public class SkillNether extends SimpleSkill<SkillNether.Config> {
         registerAdaptation(new NetherWitherResist());
         registerAdaptation(new NetherSkullYeet());
         registerAdaptation(new NetherFireResist());
+        registerAdvancement(AdaptAdvancement.builder()
+                .icon(Material.WITHER_SKELETON_SKULL)
+                .key("challenge_wither_skeleton_kill_1k")
+                .title(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_1k", "title"))
+                .description(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_1k", "description"))
+                .frame(AdvancementFrameType.CHALLENGE)
+                .visibility(AdvancementVisibility.PARENT_GRANTED)
+                .child(AdaptAdvancement.builder()
+                        .icon(Material.WITHER_SKELETON_SKULL)
+                        .key("challenge_wither_skeleton_kill_5k")
+                        .title(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_5k", "title"))
+                        .description(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_5k", "description"))
+                        .frame(AdvancementFrameType.CHALLENGE)
+                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                        .child(AdaptAdvancement.builder()
+                                .icon(Material.WITHER_SKELETON_SKULL)
+                                .key("challenge_wither_skeleton_kill_50k")
+                                .title(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_50k", "title"))
+                                .description(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_50k", "description"))
+                                .frame(AdvancementFrameType.CHALLENGE)
+                                .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                .child(AdaptAdvancement.builder()
+                                        .icon(Material.WITHER_SKELETON_SKULL)
+                                        .key("challenge_wither_skeleton_kill_500k")
+                                        .title(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_500k", "title"))
+                                        .description(Localizer.dLocalize("advancement", "challenge_wither_skeleton_kill_500k", "description"))
+                                        .frame(AdvancementFrameType.CHALLENGE)
+                                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_wither_skeleton_kill_1k").goal(1000).stat("wither_skeleton_kills").reward(getConfig().getWitherSkeletonKillXp()).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_wither_skeleton_kill_5k").goal(5000).stat("wither_skeleton_kills").reward(getConfig().getWitherSkeletonKillXp()).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_wither_skeleton_kill_50k").goal(50000).stat("wither_skeleton_kills").reward(getConfig().getWitherSkeletonKillXp()).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_wither_skeleton_kill_500k").goal(500000).stat("wither_skeleton_kills").reward(getConfig().getWitherSkeletonKillXp()).build());
     }
 
     private boolean shouldReturnForEventWithCause(Player p, EntityDamageEvent.DamageCause cause) {

--- a/src/main/java/com/volmit/adapt/content/skill/SkillRanged.java
+++ b/src/main/java/com/volmit/adapt/content/skill/SkillRanged.java
@@ -18,7 +18,10 @@
 
 package com.volmit.adapt.content.skill;
 
+import com.volmit.adapt.api.advancement.AdaptAdvancement;
+import com.volmit.adapt.api.advancement.AdvancementVisibility;
 import com.volmit.adapt.api.skill.SimpleSkill;
+import com.volmit.adapt.api.world.AdaptStatTracker;
 import com.volmit.adapt.content.adaptation.ranged.*;
 import com.volmit.adapt.util.C;
 import com.volmit.adapt.util.Localizer;
@@ -54,6 +57,44 @@ public class SkillRanged extends SimpleSkill<SkillRanged.Config> {
         registerAdaptation(new RangedWebBomb());
         setIcon(Material.CROSSBOW);
         cooldowns = new HashMap<>();
+
+        registerAdvancement(AdaptAdvancement.builder()
+                .icon(Material.BOW)
+                .key("challenge_ranged_1k")
+                .title(Localizer.dLocalize("advancement", "challenge_ranged_1k", "title"))
+                .description(Localizer.dLocalize("advancement", "challenge_ranged_1k", "description"))
+                .frame(AdvancementFrameType.CHALLENGE)
+                .visibility(AdvancementVisibility.PARENT_GRANTED)
+                .child(AdaptAdvancement.builder()
+                        .icon(Material.CROSSBOW)
+                        .key("challenge_ranged_5k")
+                        .title(Localizer.dLocalize("advancement", "challenge_ranged_5k", "title"))
+                        .description(Localizer.dLocalize("advancement", "challenge_ranged_5k", "description"))
+                        .frame(AdvancementFrameType.CHALLENGE)
+                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                        .child(AdaptAdvancement.builder()
+                                .icon(Material.TIPPED_ARROW)
+                                .key("challenge_ranged_50k")
+                                .title(Localizer.dLocalize("advancement", "challenge_ranged_50k", "title"))
+                                .description(Localizer.dLocalize("advancement", "challenge_ranged_50k", "description"))
+                                .frame(AdvancementFrameType.CHALLENGE)
+                                .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                .child(AdaptAdvancement.builder()
+                                        .icon(Material.SPECTRAL_ARROW)
+                                        .key("challenge_ranged_500k")
+                                        .title(Localizer.dLocalize("advancement", "challenge_ranged_500k", "title"))
+                                        .description(Localizer.dLocalize("advancement", "challenge_ranged_500k", "description"))
+                                        .frame(AdvancementFrameType.CHALLENGE)
+                                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_ranged_1k").goal(1000).stat("ranged.shotsfired").reward(getConfig().challengeRanged1kReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_ranged_5k").goal(5000).stat("ranged.shotsfired").reward(getConfig().challengeRanged5kReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_ranged_50k").goal(50000).stat("ranged.shotsfired").reward(getConfig().challengeRanged50kReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_ranged_500k").goal(500000).stat("ranged.shotsfired").reward(getConfig().challengeRanged500kReward).build());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -124,5 +165,9 @@ public class SkillRanged extends SimpleSkill<SkillRanged.Config> {
         long cooldownDelay = 1250;
         double hitDamageXPMultiplier = 2.125;
         double hitDistanceXPMultiplier = 1.7;
+        double challengeRanged1kReward = 1000;
+        double challengeRanged5kReward = 5000;
+        double challengeRanged50kReward = 50000;
+        double challengeRanged500kReward = 500000;
     }
 }

--- a/src/main/java/com/volmit/adapt/content/skill/SkillRanged.java
+++ b/src/main/java/com/volmit/adapt/content/skill/SkillRanged.java
@@ -18,6 +18,7 @@
 
 package com.volmit.adapt.content.skill;
 
+import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
 import com.volmit.adapt.api.advancement.AdaptAdvancement;
 import com.volmit.adapt.api.advancement.AdvancementVisibility;
 import com.volmit.adapt.api.skill.SimpleSkill;

--- a/src/main/java/com/volmit/adapt/content/skill/SkillRift.java
+++ b/src/main/java/com/volmit/adapt/content/skill/SkillRift.java
@@ -18,9 +18,11 @@
 
 package com.volmit.adapt.content.skill;
 
+import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
 import com.volmit.adapt.api.advancement.AdaptAdvancement;
 import com.volmit.adapt.api.advancement.AdvancementVisibility;
 import com.volmit.adapt.api.skill.SimpleSkill;
+import com.volmit.adapt.api.world.AdaptStatTracker;
 import com.volmit.adapt.content.adaptation.rift.*;
 import com.volmit.adapt.util.C;
 import com.volmit.adapt.util.Localizer;

--- a/src/main/java/com/volmit/adapt/content/skill/SkillRift.java
+++ b/src/main/java/com/volmit/adapt/content/skill/SkillRift.java
@@ -18,6 +18,8 @@
 
 package com.volmit.adapt.content.skill;
 
+import com.volmit.adapt.api.advancement.AdaptAdvancement;
+import com.volmit.adapt.api.advancement.AdvancementVisibility;
 import com.volmit.adapt.api.skill.SimpleSkill;
 import com.volmit.adapt.content.adaptation.rift.*;
 import com.volmit.adapt.util.C;
@@ -56,6 +58,44 @@ public class SkillRift extends SimpleSkill<SkillRift.Config> {
         registerAdaptation(new RiftBlink());
         registerAdaptation(new RiftDescent());
         lasttp = new HashMap<>();
+
+        registerAdvancement(AdaptAdvancement.builder()
+                .icon(Material.ENDER_EYE)
+                .key("challenge_rift_1k")
+                .title(Localizer.dLocalize("advancement", "challenge_rift_1k", "title"))
+                .description(Localizer.dLocalize("advancement", "challenge_rift_1k", "description"))
+                .frame(AdvancementFrameType.CHALLENGE)
+                .visibility(AdvancementVisibility.PARENT_GRANTED)
+                .child(AdaptAdvancement.builder()
+                        .icon(Material.ENDER_PEARL)
+                        .key("challenge_rift_5k")
+                        .title(Localizer.dLocalize("advancement", "challenge_rift_5k", "title"))
+                        .description(Localizer.dLocalize("advancement", "challenge_rift_5k", "description"))
+                        .frame(AdvancementFrameType.CHALLENGE)
+                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                        .child(AdaptAdvancement.builder()
+                                .icon(Material.END_CRYSTAL)
+                                .key("challenge_rift_50k")
+                                .title(Localizer.dLocalize("advancement", "challenge_rift_50k", "title"))
+                                .description(Localizer.dLocalize("advancement", "challenge_rift_50k", "description"))
+                                .frame(AdvancementFrameType.CHALLENGE)
+                                .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                .child(AdaptAdvancement.builder()
+                                        .icon(Material.END_PORTAL_FRAME)
+                                        .key("challenge_rift_500k")
+                                        .title(Localizer.dLocalize("advancement", "challenge_rift_500k", "title"))
+                                        .description(Localizer.dLocalize("advancement", "challenge_rift_500k", "description"))
+                                        .frame(AdvancementFrameType.CHALLENGE)
+                                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_rift_1k").goal(1000).stat("rift.teleports").reward(getConfig().challengeRift1kReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_rift_5k").goal(5000).stat("rift.teleports").reward(getConfig().challengeRift5kReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_rift_50k").goal(50000).stat("rift.teleports").reward(getConfig().challengeRift50kReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_rift_500k").goal(500000).stat("rift.teleports").reward(getConfig().challengeRift500kReward).build());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -159,5 +199,9 @@ public class SkillRift extends SimpleSkill<SkillRift.Config> {
         double throwEnderEyeXP = 45;
         double teleportXP = 15;
         double teleportXPCooldown = 60000;
+        double challengeRift1kReward = 1000;
+        double challengeRift5kReward = 5000;
+        double challengeRift50kReward = 50000;
+        double challengeRift500kReward = 500000;
     }
 }

--- a/src/main/java/com/volmit/adapt/content/skill/SkillSeaborne.java
+++ b/src/main/java/com/volmit/adapt/content/skill/SkillSeaborne.java
@@ -60,12 +60,39 @@ public class SkillSeaborne extends SimpleSkill<SkillSeaborne.Config> {
         registerAdvancement(AdaptAdvancement.builder()
                 .icon(Material.TURTLE_HELMET)
                 .key("challenge_swim_1nm")
-                .title("Human Submarine!")
-                .description("Swim 1 Nautical Mile (1,852 blocks)")
+                .title(Localizer.dLocalize("advancement", "challenge_swim_1nm", "title"))
+                .description(Localizer.dLocalize("advancement", "challenge_swim_1nm", "description"))
                 .frame(AdvancementFrameType.CHALLENGE)
                 .visibility(AdvancementVisibility.PARENT_GRANTED)
+                .child(AdaptAdvancement.builder()
+                        .icon(Material.HEART_OF_THE_SEA)
+                        .key("challenge_swim_5nm")
+                        .title(Localizer.dLocalize("advancement", "challenge_swim_5nm", "title"))
+                        .description(Localizer.dLocalize("advancement", "challenge_swim_5nm", "description"))
+                        .frame(AdvancementFrameType.CHALLENGE)
+                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                        .child(AdaptAdvancement.builder()
+                                .icon(Material.NAUTILUS_SHELL)
+                                .key("challenge_swim_50nm")
+                                .title(Localizer.dLocalize("advancement", "challenge_swim_50nm", "title"))
+                                .description(Localizer.dLocalize("advancement", "challenge_swim_50nm", "description"))
+                                .frame(AdvancementFrameType.CHALLENGE)
+                                .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                .child(AdaptAdvancement.builder()
+                                        .icon(Material.CONDUIT)
+                                        .key("challenge_swim_500nm")
+                                        .title(Localizer.dLocalize("advancement", "challenge_swim_500nm", "title"))
+                                        .description(Localizer.dLocalize("advancement", "challenge_swim_500nm", "description"))
+                                        .frame(AdvancementFrameType.CHALLENGE)
+                                        .visibility(AdvancementVisibility.PARENT_GRANTED)
+                                        .build())
+                                .build())
+                        .build())
                 .build());
         registerStatTracker(AdaptStatTracker.builder().advancement("challenge_swim_1nm").goal(1852).stat("move.swim").reward(getConfig().challengeSwim1nmReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_swim_5nm").goal(9260).stat("move.swim").reward(getConfig().challengeSwim5nmReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_swim_50nm").goal(92600).stat("move.swim").reward(getConfig().challengeSwim50nmReward).build());
+        registerStatTracker(AdaptStatTracker.builder().advancement("challenge_swim_500nm").goal(926000).stat("move.swim").reward(getConfig().challengeSwim500nmReward).build());
         cooldowns = new HashMap<>();
     }
 
@@ -163,6 +190,9 @@ public class SkillSeaborne extends SimpleSkill<SkillSeaborne.Config> {
         double damagedrownxpmultiplier = 3;
         boolean enabled = true;
         double challengeSwim1nmReward = 750;
+        double challengeSwim5nmReward = 1500;
+        double challengeSwim50nmReward = 7500;
+        double challengeSwim500nmReward = 15000;
         double swimXP = 28.7;
     }
 }

--- a/src/main/resources/en_US.json
+++ b/src/main/resources/en_US.json
@@ -231,8 +231,71 @@
     "challenge_pickaxe_5m": {
       "title": "Legendary Miner",
       "description": "Break 5,000,000 Blocks"
+    },
+    "challenge_wither_skeleton_kill_1k": {
+      "title": "Wither Skeleton Slayer",
+      "description": "Kill 1,000 Wither Skeletons"
+    },
+    "challenge_wither_skeleton_kill_5k": {
+      "title": "Wither Skeleton Hunter",
+      "description": "Kill 5,000 Wither Skeletons"
+    },
+    "challenge_wither_skeleton_kill_50k": {
+      "title": "Wither Skeleton Conqueror",
+      "description": "Kill 50,000 Wither Skeletons"
+    },
+    "challenge_wither_skeleton_kill_500k": {
+      "title": "Wither Skeleton Annihilator",
+      "description": "Kill 500,000 Wither Skeletons"
+    },
+    "challenge_ranged_1k": {
+      "title": "Novice Archer",
+      "description": "Fire 1,000 Shots"
+    },
+    "challenge_ranged_5k": {
+      "title": "Skilled Archer",
+      "description": "Fire 5,000 Shots"
+    },
+    "challenge_ranged_50k": {
+      "title": "Expert Archer",
+      "description": "Fire 50,000 Shots"
+    },
+    "challenge_ranged_500k": {
+      "title": "Master Archer",
+      "description": "Fire 500,000 Shots"
+    },
+    "challenge_rift_1k": {
+      "title": "Novice Teleporter",
+      "description": "Teleport 1,000 Times"
+    },
+    "challenge_rift_5k": {
+      "title": "Skilled Teleporter",
+      "description": "Teleport 5,000 Times"
+    },
+    "challenge_rift_50k": {
+      "title": "Expert Teleporter",
+      "description": "Teleport 50,000 Times"
+    },
+    "challenge_rift_500k": {
+      "title": "Master Teleporter",
+      "description": "Teleport 500,000 Times"
+    },
+    "challenge_swim_1nm": {
+      "title": "Novice Swimmer",
+      "description": "Swim 1 Nautical Mile (1,852 blocks)"
+    },
+    "challenge_swim_5nm": {
+      "title": "Skilled Swimmer",
+      "description": "Swim 5 Nautical Miles (9,260 blocks)"
+    },
+    "challenge_swim_50nm": {
+      "title": "Expert Swimmer",
+      "description": "Swim 50 Nautical Miles (92,600 blocks)"
+    },
+    "challenge_swim_500nm": {
+      "title": "Master Swimmer",
+      "description": "Swim 500 Nautical Miles (926,000 blocks)"
     }
-
   },
   "items": {
     "boundenderperal": {

--- a/src/main/resources/en_US.json
+++ b/src/main/resources/en_US.json
@@ -234,19 +234,19 @@
     },
     "challenge_wither_skeleton_kill_1k": {
       "title": "Wither Skeleton Slayer",
-      "description": "Kill 1,000 Wither Skeletons"
+      "description": "You really dont like these guys do you?"
     },
     "challenge_wither_skeleton_kill_5k": {
       "title": "Wither Skeleton Hunter",
-      "description": "Kill 5,000 Wither Skeletons"
+      "description": "Ok, you really dont like these guys are you done?"
     },
     "challenge_wither_skeleton_kill_50k": {
       "title": "Wither Skeleton Conqueror",
-      "description": "Kill 50,000 Wither Skeletons"
+      "description": "Stop killing these guys, they have families!"
     },
     "challenge_wither_skeleton_kill_500k": {
       "title": "Wither Skeleton Annihilator",
-      "description": "Kill 500,000 Wither Skeletons"
+      "description": "What on gods earth made you kill this many..."
     },
     "challenge_ranged_1k": {
       "title": "Novice Archer",
@@ -265,11 +265,11 @@
       "description": "Fire 500,000 Shots"
     },
     "challenge_rift_1k": {
-      "title": "Novice Teleporter",
+      "title": "Novice V'Woop-er",
       "description": "Teleport 1,000 Times"
     },
     "challenge_rift_5k": {
-      "title": "Skilled Teleporter",
+      "title": "Skilled Portal Jumper",
       "description": "Teleport 5,000 Times"
     },
     "challenge_rift_50k": {
@@ -277,8 +277,8 @@
       "description": "Teleport 50,000 Times"
     },
     "challenge_rift_500k": {
-      "title": "Master Teleporter",
-      "description": "Teleport 500,000 Times"
+      "title": "Master Ender-person (Teleporter)",
+      "description": "Teleport 500,000 Times, Woah..."
     },
     "challenge_swim_1nm": {
       "title": "Novice Swimmer",


### PR DESCRIPTION
Add advancements and translations for Brewing, Nether, Ranged, Rift, and Seaborne skills.

* **SkillNether.java**
  - Add advancements for killing Wither Skeletons.
  - Register stat trackers for Wither Skeleton kills.
* **SkillRanged.java**
  - Add advancements for firing shots.
  - Register stat trackers for shots fired.
* **SkillRift.java**
  - Add advancements for teleporting.
  - Register stat trackers for teleports.
* **SkillSeaborne.java**
  - Add advancements for swimming.
  - Register stat trackers for swimming.
* **en_US.json**
  - Add translation keys for advancements related to Wither Skeleton kills, shots fired, teleports, and swimming.
